### PR TITLE
Don't inject js/css from purposes created by non-owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It's got a whole copy of Chrome.
 #### Nobody on my team is using this
 
  * Create `#slack-hacks`.
- * Add space-separated `.js` and `.css` asset URLs to the purpose (not topic!) of the `#slack-hacks` channel. Other text will be ignored. In order to be compatible with Slack's CSP, we use a unique URL scheme. Instead of `http` and `https`, use `hax` and `haxs`, respectively. There are some examples below :point_down:.
+ * Add space-separated `.js` and `.css` asset URLs to the purpose (not topic!) of the `#slack-hacks` channel. Other text will be ignored. In order to be compatible with Slack's CSP, we use a unique URL scheme. Instead of `http` and `https`, use `hax` and `haxs`, respectively. To provide a modicum of security, a team owner must edit the channel purpose that injects the links. There are some examples below :point_down:.
  * Use the client normally. You might need to refresh (cmd-r) if you joined
 
 #### Examples

--- a/app/localhax/slack-hacks-loader.js
+++ b/app/localhax/slack-hacks-loader.js
@@ -44,7 +44,7 @@
       return
     }
 
-    TS.members.ensureMemberIsPresent({ user: channel.purpose.creator}).then(function(arg1, arg2, arg3) {
+    TS.members.ensureMemberIsPresent({ user: channel.purpose.creator}).then(function() {
       creator = TS.members.getMemberById(channel.purpose.creator);
       console.log("Channel purpose was created by " + creator.name);
       if (!creator.is_owner) {

--- a/app/localhax/slack-hacks-loader.js
+++ b/app/localhax/slack-hacks-loader.js
@@ -43,22 +43,32 @@
     } else {
       return
     }
-    words = channel_purpose.split(/\s+/);
-    urls = [];
-    for (i = 0, len = words.length; i < len; i++) {
-      word = words[i];
-      if (word.match(url_regex)) {
-        urls.push(word);
+
+    TS.members.ensureMemberIsPresent({ user: channel.purpose.creator}).then(function(arg1, arg2, arg3) {
+      creator = TS.members.getMemberById(channel.purpose.creator);
+      console.log("Channel purpose was created by " + creator.name);
+      if (!creator.is_owner) {
+        console.log("Refusing to inject hacks from channel purpose created by non-admin " + creator.name + ": " + channel_purpose);
+        return;
       }
-    }
-    console.log(words);
-    console.log(urls);
-    results = [];
-    for (j = 0, len1 = urls.length; j < len1; j++) {
-      url = urls[j];
-      results.push(insertUrl(url));
-    }
-    return results;
+
+      words = channel_purpose.split(/\s+/);
+      urls = [];
+      for (i = 0, len = words.length; i < len; i++) {
+        word = words[i];
+        if (word.match(url_regex)) {
+          urls.push(word);
+        }
+      }
+      console.log(words);
+      console.log(urls);
+      results = [];
+      for (j = 0, len1 = urls.length; j < len1; j++) {
+        url = urls[j];
+        results.push(insertUrl(url));
+      }
+      return results;
+    });
   };
 
   slackHacksLoader()


### PR DESCRIPTION
cc @mastahyeti. This adds a check that refuses to inject css/js unless a team owner was the last person to edit the channel purpose that references them. An improvement if not perfect.
