### PR TITLE
User-specific hacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,29 @@ experience. It's a standalone Mac app that's simple to install.
 Installation
 ============
 
- * Download <https://dinosaur.s3.amazonaws.com/hackable-slack-client-0.2.0.zip> and
+First, download <https://dinosaur.s3.amazonaws.com/hackable-slack-client-0.2.0.zip> and
 drag the Hackable Slack Client to your Applications folder. Sorry it's so big.
 It's got a whole copy of Chrome.
- * Ask yourself which applies below: has **someone set this up** for your team,
- or are you the first for your team?
 
-#### Someone on my team has set this up
+Next, decide how you want to inject hacks into the client.
+
+#### Someone on my team set this up, and I want to use it.
 
  * Join `#slack-hacks`.
  * Use the client normally. You might need to refresh (cmd-r) if you joined
- after installing the client.
+ #slack-hacks after installing the client.
 
-#### Nobody on my team is using this
+#### I want to set this up so my whole team can use some hacks
 
  * Create `#slack-hacks`.
  * Add space-separated `.js` and `.css` asset URLs to the purpose (not topic!) of the `#slack-hacks` channel. Other text will be ignored. In order to be compatible with Slack's CSP, we use a unique URL scheme. Instead of `http` and `https`, use `hax` and `haxs`, respectively. To provide a modicum of security, a team owner must edit the channel purpose that injects the links. There are some examples below :point_down:.
  * Use the client normally. You might need to refresh (cmd-r) if you joined
 
-#### Examples
+#### I just want to use this myself, or I want to overwrite some team-wide hacks
+ * Add `hax://` or `haxs://` URLs to the `title` field of your profile at
+ `https://my.slack.com/account/profile`. Reload the client after adding URLs.
+
+#### Example Hacks
 
 If you'd like to use some sample asset changes, set your `#slack-hacks` purpose
 (not topic) to be this:
@@ -52,7 +56,8 @@ help you load code.
 
 Upon loading, a javascript file will be injected into the page. This file is
 static. This file finds the `#slack-hacks` channel, finds its `purpose`, and
-parses asset URL from it. These are then injected to the page.
+parses asset URL from it. These are then injected to the page. After these have
+been injected, asset URLs from the `title` field of your profile will be loaded.
 
 
 ###### Hacking
@@ -63,7 +68,7 @@ there apply for contributions to the main application.
 
 If you'd like to do local development for assets, just add their URLs to the
 purpose of the `#slack-hacks` room. If you have joined a `#slack-hacks-dev`
-room, those assets will be used instead. Assets must come from HTTPs hosts.
+room, those assets will be used instead.
 
 Use `cmd-alt-i` to open the web inspector to see what CSS you can add.
 Javascript is more challenging, but slack's javascript minification is not


### PR DESCRIPTION
Implements per-user hax in addition to team-wide hax. User hax are pulled from the `title` field of the profile at `https://my.slack.com/account/profile`, which can hold an absurdly long string but no newlines. User hax are injected after team hax, so they'll have CSS priority.

cc @jwieletemann @dvillega. cc @zerowidth who was saying that helvetica wasn't his style: go add `hax://bhuga.github.io/slacks-hacks-snippets/remove-helvetica.css` to your title and restart.

I pushed this version a few hours ago and your client has probably auto-updated if you're reading this. It's just for informational purposes. Quit/restart for the goodness.
