### PR TITLE
Set badge on OSX only

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -95,7 +95,9 @@ app.on('ready', function () {
   });
 
   ipc.on('badge', function(event, arg) {
-    app.dock.setBadge(arg.badge_text);
+    if (process.platform === 'darwin') {
+      app.dock.setBadge(arg.badge_text);
+    }
   });
 
   app.on('zoom-in', function(event, arg) {


### PR DESCRIPTION
Displays a popup in a loop otherwise under Debian/GNOME.

![hackable-error_002](https://cloud.githubusercontent.com/assets/10998/13932427/48d89e8e-efa8-11e5-8ffb-b67b96181d1a.png).

@bhuga may not be the best fix given that I don't know what I'm doing, but works here.
