### PR TITLE
load hacks on an interval

### DIFF
--- a/app/localhax/slack-hacks-loader.js
+++ b/app/localhax/slack-hacks-loader.js
@@ -74,13 +74,14 @@
     });
   };
 
-  // I haven't figured out exactly which slack loading event is appropriate; the data
-  // we need appears to be racey with the ones I've found. This tries to load
-  // right away, and if we don't find a channel, we try again after some boot events.
-  slackHacksLoader()
-  if (window.slackHacksLoaded != true) {
-    TS.channels.data_updated_sig.addOnce(slackHacksLoader);
-    TS.client.login_sig.addOnce(slackHacksLoader);
-  }
+  // slack actually loads a couple of different ways while the incremental boot
+  // feature flag is going to some users but not all, so we'll just try until
+  // #slack-hacks is loaded.
+  var loaderInterval = setInterval(function() {
+    slackHacksLoader()
+    if (window.slackHacksLoaded != true) {
+      clearInterval(loaderInterval)
+    }
+  }, 1000);
 
 }).call(this);


### PR DESCRIPTION
Loads hacks on an interval now that a new feature flag, `TS.boot_data.feature_incremental_boot`, is being rolled out. The assumptions from the old signals are no longer valid.

@aaronbbrown can you try this branch out?
