### PR TITLE
Replace esperanto with babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "devDependencies": {
     "asar": "^0.7.2",
     "electron-prebuilt": "0.36.4",
-    "esperanto": "^0.7.2",
     "fs-jetpack": "^0.6.5",
     "gulp": "^3.9.0",
+    "gulp-babel": "^6.1.2",
     "gulp-less": "^3.0.3",
     "gulp-util": "^3.0.6",
     "q": "^1.4.1",

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -2,7 +2,7 @@
 
 var gulp = require('gulp');
 var less = require('gulp-less');
-var esperanto = require('esperanto');
+var babel = require('gulp-babel');
 var map = require('vinyl-map');
 var jetpack = require('fs-jetpack');
 
@@ -65,14 +65,7 @@ gulp.task('copy-watch', copyTask);
 
 var transpileTask = function () {
     return gulp.src(paths.jsCodeToTranspile)
-    .pipe(map(function(code, filename) {
-        try {
-            var transpiled = esperanto.toAmd(code.toString(), { strict: true });
-        } catch (err) {
-            throw new Error(err.message + ' ' + filename);
-        }
-        return transpiled.code;
-    }))
+    .pipe(babel())
     .pipe(gulp.dest(destDir.path()));
 };
 gulp.task('transpile', ['clean'], transpileTask);


### PR DESCRIPTION
Esperanto is deprecated, and on build it's been nagging about switching to something supported like babel. The transition was straightforward and it seems to work fine. Probably needs testing by people who aren't me though.
