### PR TITLE
Fix right-click react menu

### DIFF
--- a/app/expose-window-apis.js
+++ b/app/expose-window-apis.js
@@ -169,6 +169,7 @@ process.once('loaded', function(){
         regularMenu.popup(electron.remote.getCurrentWindow());
       }
     } else {
+      msg.target = msg_el
       window.next_react_msg = msg
       window.next_rxn_key = TS.rxns.getRxnKeyByMsgType(msg);
       if (typeof href == "string") {


### PR DESCRIPTION
Slack's new react-based reaction emoji selector asks for a `target` from `next_react_msg`. I have no idea if the old stuff is still needed but this makes it work again.

cc @grantr, intrepid bug reporter.